### PR TITLE
add all-gather support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,10 @@ find_package(CUDA 11.0 REQUIRED)
 find_package(MPI REQUIRED)
 
 include_directories(${MPI_INCLUDE_PATH})
-include_directories("/home/ssingh37/nccl/build/include")
-link_directories("/home/ssingh37/nccl/build/lib")
+# include_directories("/home/ssingh37/nccl/build/include")
+# link_directories("/home/ssingh37/nccl/build/lib")
+include_directories("/scratch/zt1/project/bhatele-lab/shared/nccl/build/include")
+link_directories("/scratch/zt1/project/bhatele-lab/shared/nccl/build/lib")
 
 add_library(nccl4py SHARED op.cpp)
 target_link_libraries(nccl4py "${TORCH_LIBRARIES}")

--- a/test.py
+++ b/test.py
@@ -17,9 +17,17 @@ if __name__ == "__main__":
     torch.cuda.synchronize()
     print(x, x.dtype)
 
+    y = torch.zeros(2*size, 3, device='cuda').half()
+    torch.ops.nccl4py.all_gather_fp16(x, y)
+    torch.cuda.synchronize()
+    print(y, y.dtype)
 
     x = torch.ones(2,3, device='cuda', dtype=torch.float32)
     torch.ops.nccl4py.all_reduce_fp32(x)
     torch.cuda.synchronize()
     print(x, x.dtype)
 
+    y = torch.zeros(2*size, 3, device='cuda', dtype=torch.float32)
+    torch.ops.nccl4py.all_gather_fp32(x, y)
+    torch.cuda.synchronize()
+    print(y, y.dtype)


### PR DESCRIPTION
### Features
- Adding support for `all_gather_fp16` and `all_gather_fp32`. Follows conventions of the all-reduce implementation in `op.cpp` and builds successfully to `build/libnccl4py.so`

#### Bug fixes
- Also fixed `CUDACHECK` in `op.cpp` that was giving problems when trying to run earlier. Retrieved that from nvidia [here](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/examples.html), also commented in code

#### Etc
- Also commented out previous pointed to NCCL to the shared Zaratan build. Siddharth will create more permanent solution in a future commit 

### Testing
Adds additional testing in `test.py` for both all-gather functions. Expected output is a 4x3 matrix of 2's for each function, with the `dtype` being 16-bit and 32-bit floats, respectively. Tested with varying output `y` matrix sizes (e.g. 2x3 and 6x3) and output is as expected for an all-gather operation